### PR TITLE
Two minor fixes

### DIFF
--- a/include/llvm-c/Transforms/Tapir.h
+++ b/include/llvm-c/Transforms/Tapir.h
@@ -36,7 +36,7 @@ extern "C" {
 /** See llvm::createLoopSpawningPass function. */
 void LLVMAddLoopSpawningPass(LLVMPassManagerRef PM);
 
-/** See llvm::createCilkPassPass function. */
+/** See llvm::createLowerTapirToCilkPass function. */
 void LLVMAddLowerTapirToCilkPass(LLVMPassManagerRef PM);
 
 /**


### PR DESCRIPTION
One fix to a function name mentioned in a comment.

Other fix properly removes traces of the /tools/clang/ submodule. Prior to this patch, the current state of the git index on "master" of wsmoses/Parallel-IR still remembers that there is a directory /tools/clang/ which was a submodule, which may cause confusion among 6.S898 class members who are unfamiliar with git submodules when they try to look at git status reports, or do a local "git add --all" or "git commit -a" after making some changes to clang.