### PR TITLE
Added nworkers call for openmp abi to fix DAC codegen

### DIFF
--- a/include/llvm/Transforms/Tapir/OpenMPABI.h
+++ b/include/llvm/Transforms/Tapir/OpenMPABI.h
@@ -51,6 +51,7 @@ enum OpenMPRuntimeFunction {
   OMPRTL__kmpc_omp_taskwait,
   OMPRTL__kmpc_global_thread_num,
   OMPRTL__kmpc_barrier,
+  OMPRTL__kmpc_global_num_threads,
 };
 
 enum OpenMPSchedType {


### PR DESCRIPTION
This fixes the issue with the compiler crashing when parallel for loops are used with the openmp backend. 