### PR TITLE
Fix type mismatch

### DIFF
--- a/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+++ b/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
@@ -713,8 +713,8 @@ private:
 
   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
 
-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
-                                      uint64_t Size) {
+  Expected<std::vector<unsigned char>> readMem(char *Dst, JITTargetAddress Src,
+                                               uint64_t Size) {
     // Check for an 'out-of-band' error, e.g. from an MM destructor.
     if (ExistingError)
       return std::move(ExistingError);


### PR DESCRIPTION
This version doesn't compile with gcc 8.2.0 on Debian. See: https://bugzilla.redhat.com/show_bug.cgi?id=1540620. The change is essentially the same patch as this: https://bugzilla.redhat.com/attachment.cgi?id=1389687.