### PR TITLE
[AliasAnalysis] Avoid unnecessary recursion on nested detaches.

### DIFF
--- a/lib/Analysis/AliasAnalysis.cpp
+++ b/lib/Analysis/AliasAnalysis.cpp
@@ -672,7 +672,7 @@ ModRefInfo AAResults::getModRefInfo(const DetachInst *D,
 
       // No need to recursively check nested syncs or detaches, as nested tasks
       // are wholly contained in the detached sub-CFG we're iterating through.
-      if (isa<SyncInst>(&*I) || isa<DetachInst>(&*I))
+      if (isa<SyncInst>(I) || isa<DetachInst>(I))
         continue;
 
       Result = unionModRef(Result, getModRefInfo(&I, Loc));

--- a/lib/Analysis/AliasAnalysis.cpp
+++ b/lib/Analysis/AliasAnalysis.cpp
@@ -666,13 +666,14 @@ ModRefInfo AAResults::getModRefInfo(const DetachInst *D,
       continue;
 
     for (const Instruction &I : *BB) {
-      // Ignore sync instructions in this analysis
-      if (isa<SyncInst>(I))
-	continue;
-
       // Fail fast if we encounter an invalid CFG.
       assert(!(D == &I) &&
              "Invalid CFG found: Detached CFG reaches its own Detach.");
+
+      // No need to recursively check nested syncs or detaches, as nested tasks
+      // are wholly contained in the detached sub-CFG we're iterating through.
+      if (isa<SyncInst>(&*I) || isa<DetachInst>(&*I))
+        continue;
 
       Result = unionModRef(Result, getModRefInfo(&I, Loc));
 


### PR DESCRIPTION
This addresses https://github.com/wsmoses/Tapir-LLVM/issues/92

This ensures getModRefInfo runs in linear time,
and avoids unbounded stack growth.